### PR TITLE
feat(custom-plugins): added logic to support custom plugins that are easy to build WIP

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -1377,14 +1377,14 @@ export declare interface RtkFullscreenToggle extends Components.RtkFullscreenTog
 
 
 @ProxyCmp({
-  inputs: ['aspectRatio', 'config', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'overrides', 'size', 'states', 't']
+  inputs: ['aspectRatio', 'config', 'customPlugins', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'overrides', 'size', 'states', 't']
 })
 @Component({
   selector: 'rtk-grid',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['aspectRatio', 'config', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'overrides', 'size', 'states', 't'],
+  inputs: ['aspectRatio', 'config', 'customPlugins', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'overrides', 'size', 'states', 't'],
 })
 export class RtkGrid {
   protected el: HTMLRtkGridElement;
@@ -1829,14 +1829,14 @@ export declare interface RtkMarkdownView extends Components.RtkMarkdownView {}
 
 
 @ProxyCmp({
-  inputs: ['applyDesignSystem', 'config', 'gridLayout', 'iconPack', 'leaveOnUnmount', 'loadConfigFromPreset', 'meeting', 'mode', 'overrides', 'showSetupScreen', 'size', 't']
+  inputs: ['applyDesignSystem', 'config', 'customPlugins', 'gridLayout', 'iconPack', 'leaveOnUnmount', 'loadConfigFromPreset', 'meeting', 'mode', 'overrides', 'showSetupScreen', 'size', 't']
 })
 @Component({
   selector: 'rtk-meeting',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['applyDesignSystem', 'config', 'gridLayout', 'iconPack', 'leaveOnUnmount', 'loadConfigFromPreset', 'meeting', 'mode', 'overrides', 'showSetupScreen', 'size', 't'],
+  inputs: ['applyDesignSystem', 'config', 'customPlugins', 'gridLayout', 'iconPack', 'leaveOnUnmount', 'loadConfigFromPreset', 'meeting', 'mode', 'overrides', 'showSetupScreen', 'size', 't'],
 })
 export class RtkMeeting {
   protected el: HTMLRtkMeetingElement;
@@ -2050,14 +2050,14 @@ export declare interface RtkMicrophoneSelector extends Components.RtkMicrophoneS
 
 
 @ProxyCmp({
-  inputs: ['aspectRatio', 'config', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'participants', 'pinnedParticipants', 'plugins', 'screenShareParticipants', 'size', 'states', 't']
+  inputs: ['aspectRatio', 'config', 'customPlugins', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'participants', 'pinnedParticipants', 'plugins', 'screenShareParticipants', 'size', 'states', 't']
 })
 @Component({
   selector: 'rtk-mixed-grid',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['aspectRatio', 'config', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'participants', 'pinnedParticipants', 'plugins', 'screenShareParticipants', 'size', 'states', 't'],
+  inputs: ['aspectRatio', 'config', 'customPlugins', 'gap', 'gridSize', 'iconPack', 'layout', 'meeting', 'participants', 'pinnedParticipants', 'plugins', 'screenShareParticipants', 'size', 'states', 't'],
 })
 export class RtkMixedGrid {
   protected el: HTMLRtkMixedGridElement;
@@ -2684,14 +2684,14 @@ export declare interface RtkPipToggle extends Components.RtkPipToggle {
 
 
 @ProxyCmp({
-  inputs: ['iconPack', 'meeting', 'plugin', 't']
+  inputs: ['customPlugin', 'customPlugins', 'iconPack', 'meeting', 'plugin', 't']
 })
 @Component({
   selector: 'rtk-plugin-main',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['iconPack', 'meeting', 'plugin', 't'],
+  inputs: ['customPlugin', 'customPlugins', 'iconPack', 'meeting', 'plugin', 't'],
 })
 export class RtkPluginMain {
   protected el: HTMLRtkPluginMainElement;
@@ -2706,14 +2706,14 @@ export declare interface RtkPluginMain extends Components.RtkPluginMain {}
 
 
 @ProxyCmp({
-  inputs: ['config', 'iconPack', 'meeting', 'size', 't']
+  inputs: ['config', 'customPlugins', 'iconPack', 'meeting', 'size', 'states', 't']
 })
 @Component({
   selector: 'rtk-plugins',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['config', 'iconPack', 'meeting', 'size', 't'],
+  inputs: ['config', 'customPlugins', 'iconPack', 'meeting', 'size', 'states', 't'],
 })
 export class RtkPlugins {
   protected el: HTMLRtkPluginsElement;
@@ -3586,14 +3586,14 @@ export declare interface RtkTranscripts extends Components.RtkTranscripts {}
 
 
 @ProxyCmp({
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'overrides', 'showSetupScreen', 't']
+  inputs: ['config', 'customPlugins', 'iconPack', 'meeting', 'mode', 'overrides', 'showSetupScreen', 't']
 })
 @Component({
   selector: 'rtk-ui-provider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'overrides', 'showSetupScreen', 't'],
+  inputs: ['config', 'customPlugins', 'iconPack', 'meeting', 'mode', 'overrides', 'showSetupScreen', 't'],
 })
 export class RtkUiProvider {
   protected el: HTMLRtkUiProviderElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -6,7 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Meeting, RTKParticipant as Participant, Peer, WaitlistedParticipant } from "./types/rtk-client";
-import { Chat, Notification, PartialStateEvent, Poll, PollObject, Size, States, Transcript } from "./types/props";
+import { Chat, CustomPlugin, Notification, PartialStateEvent, Poll, PollObject, Size, States, Transcript } from "./types/props";
 import { UIConfig } from "./types/ui-config";
 import { IconPack } from "./lib/icons";
 import { RtkI18n } from "./lib/lang";
@@ -46,7 +46,7 @@ import { MeetingMode as MeetingMode1 } from "./components/rtk-meeting/rtk-meetin
 import { ViewerCountVariant } from "./components/rtk-viewer-count/rtk-viewer-count";
 import { Peer as Peer1 } from ".";
 export { Meeting, RTKParticipant as Participant, Peer, WaitlistedParticipant } from "./types/rtk-client";
-export { Chat, Notification, PartialStateEvent, Poll, PollObject, Size, States, Transcript } from "./types/props";
+export { Chat, CustomPlugin, Notification, PartialStateEvent, Poll, PollObject, Size, States, Transcript } from "./types/props";
 export { UIConfig } from "./types/ui-config";
 export { IconPack } from "./lib/icons";
 export { RtkI18n } from "./lib/lang";
@@ -1472,6 +1472,10 @@ export namespace Components {
          */
         "config": UIConfig;
         /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
+        /**
           * Gap between participants
          */
         "gap": number;
@@ -1875,6 +1879,10 @@ export namespace Components {
          */
         "config": UIConfig;
         /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
+        /**
           * Grid layout
          */
         "gridLayout": GridLayout1;
@@ -2152,6 +2160,10 @@ export namespace Components {
           * UI Config
          */
         "config": UIConfig;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
         /**
           * Gap between participant tiles
          */
@@ -2906,6 +2918,14 @@ export namespace Components {
      */
     interface RtkPluginMain {
         /**
+          * Custom Plugin (when rendering a custom plugin instead of an ordinary one)
+         */
+        "customPlugin": CustomPlugin | null;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
+        /**
           * Icon pack
          */
         "iconPack": IconPack;
@@ -2932,6 +2952,10 @@ export namespace Components {
          */
         "config": UIConfig;
         /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
+        /**
           * Icon pack
          */
         "iconPack": IconPack;
@@ -2943,6 +2967,10 @@ export namespace Components {
           * Size
          */
         "size": Size;
+        /**
+          * States
+         */
+        "states": States;
         /**
           * Language
          */
@@ -3871,6 +3899,10 @@ export namespace Components {
           * Config
          */
         "config": UIConfig1;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins": CustomPlugin[];
         /**
           * Icon pack
          */
@@ -8123,6 +8155,10 @@ declare namespace LocalJSX {
          */
         "config"?: UIConfig;
         /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
+        /**
           * Gap between participants
          */
         "gap"?: number;
@@ -8580,6 +8616,10 @@ declare namespace LocalJSX {
          */
         "config"?: UIConfig;
         /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
+        /**
           * Grid layout
          */
         "gridLayout"?: GridLayout1;
@@ -8869,6 +8909,10 @@ declare namespace LocalJSX {
           * UI Config
          */
         "config"?: UIConfig;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
         /**
           * Gap between participant tiles
          */
@@ -9658,6 +9702,14 @@ declare namespace LocalJSX {
      */
     interface RtkPluginMain {
         /**
+          * Custom Plugin (when rendering a custom plugin instead of an ordinary one)
+         */
+        "customPlugin"?: CustomPlugin | null;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
+        /**
           * Icon pack
          */
         "iconPack"?: IconPack;
@@ -9668,7 +9720,7 @@ declare namespace LocalJSX {
         /**
           * Plugin
          */
-        "plugin": RTKPlugin;
+        "plugin"?: RTKPlugin;
         /**
           * Language
          */
@@ -9683,6 +9735,10 @@ declare namespace LocalJSX {
           * Config
          */
         "config"?: UIConfig;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
         /**
           * Icon pack
          */
@@ -9699,6 +9755,10 @@ declare namespace LocalJSX {
           * Size
          */
         "size"?: Size;
+        /**
+          * States
+         */
+        "states"?: States;
         /**
           * Language
          */
@@ -10734,6 +10794,10 @@ declare namespace LocalJSX {
           * Config
          */
         "config"?: UIConfig1;
+        /**
+          * Custom Plugins
+         */
+        "customPlugins"?: CustomPlugin[];
         /**
           * Icon pack
          */

--- a/packages/core/src/components/rtk-grid/rtk-grid.tsx
+++ b/packages/core/src/components/rtk-grid/rtk-grid.tsx
@@ -3,7 +3,7 @@ import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting, Peer } from '../../types/rtk-client';
-import { Size, States } from '../../types/props';
+import { CustomPlugin, Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import debounce from 'lodash/debounce';
 import { DefaultProps, Render } from '../../lib/render';
@@ -33,6 +33,8 @@ type RoomState = 'init' | 'joined' | 'waitlisted' | leaveRoomState;
 })
 export class RtkGrid {
   private hideSelf = false;
+  private customPluginStoreSubscription: () => void;
+  private customPluginStoreRetryInterval: ReturnType<typeof setInterval>;
 
   @State() participants: Peer[] = [];
 
@@ -55,6 +57,8 @@ export class RtkGrid {
   @State() hidden: boolean = false;
 
   @State() roomState: RoomState;
+
+  @State() activeCustomPlugins: CustomPlugin[] = [];
 
   /** Grid Layout */
   @Prop({ reflect: true }) layout: GridLayout = 'row';
@@ -92,6 +96,11 @@ export class RtkGrid {
   @SyncWithStore()
   @Prop()
   t: RtkI18n = useLanguage();
+
+  /** Custom Plugins */
+  @SyncWithStore()
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
 
   /** Grid size */
   @Prop() gridSize: GridSize = defaultGridSize;
@@ -135,6 +144,16 @@ export class RtkGrid {
     participants.pinned.removeListener('participantLeft', this.onParticipantUnpinned);
     participants.joined.removeListener('screenShareUpdate', this.onScreenShareUpdate);
     participants.joined.removeListener('stageStatusUpdate', this.peerStageStatusListener);
+
+    if (this.customPluginStoreRetryInterval) {
+      clearInterval(this.customPluginStoreRetryInterval);
+      this.customPluginStoreRetryInterval = null;
+    }
+    if (this.customPluginStoreSubscription) {
+      const store = meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+      store?.unsubscribe('activePlugins', this.customPluginStoreSubscription);
+      this.customPluginStoreSubscription = null;
+    }
   }
 
   @Watch('meeting')
@@ -204,6 +223,8 @@ export class RtkGrid {
       if (meeting.stage?.status) {
         this.stageStatusListener();
       }
+
+      this.subscribeToCustomPluginStore(meeting);
     }
   }
 
@@ -223,7 +244,16 @@ export class RtkGrid {
 
   @Watch('plugins')
   pluginsChanged(plugins: RTKPlugin[]) {
-    const activePlugin = plugins.length > 0;
+    this.updateActivePluginState(plugins, this.activeCustomPlugins);
+  }
+
+  @Watch('activeCustomPlugins')
+  activeCustomPluginsChanged(activeCustomPlugins: CustomPlugin[]) {
+    this.updateActivePluginState(this.plugins, activeCustomPlugins);
+  }
+
+  private updateActivePluginState(plugins: RTKPlugin[], activeCustomPlugins: CustomPlugin[]) {
+    const activePlugin = plugins.length > 0 || activeCustomPlugins.length > 0;
     if (!!this.states.activePlugin === activePlugin) return;
 
     this.stateUpdate.emit({ activePlugin });
@@ -388,6 +418,40 @@ export class RtkGrid {
     this.updateActiveParticipants();
   };
 
+  // NOTE(retry): The store should be available immediately since the SDK awaits
+  // storesManager.create('__internal_rtk_custom_plugins') in Controller.init().
+  // However, there is currently a timing issue where either the store or
+  // customPlugins (via @SyncWithStore) may not be ready when meetingChanged fires.
+  // Retry is a temporary workaround until the root cause is fixed.
+  private subscribeToCustomPluginStore(meeting: Meeting) {
+    const trySubscribe = () => {
+      const store = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+      if (!store || !this.customPlugins?.length) return false;
+      const activeIds: string[] = store.get('activePlugins') || [];
+      this.activeCustomPlugins = (this.customPlugins || []).filter((cp) =>
+        activeIds.includes(cp.id)
+      );
+      this.customPluginStoreSubscription = () => {
+        const s = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+        const ids: string[] = s?.get('activePlugins') || [];
+        this.activeCustomPlugins = (this.customPlugins || []).filter((cp) => ids.includes(cp.id));
+      };
+      store.subscribe('activePlugins', this.customPluginStoreSubscription);
+      return true;
+    };
+
+    if (trySubscribe()) return;
+
+    let attempts = 0;
+    this.customPluginStoreRetryInterval = setInterval(() => {
+      attempts++;
+      if (trySubscribe() || attempts >= 20) {
+        clearInterval(this.customPluginStoreRetryInterval);
+        this.customPluginStoreRetryInterval = null;
+      }
+    }, 500);
+  }
+
   private updateRoomStateListener = () => {
     this.roomState = this.meeting.self.roomState;
   };
@@ -480,6 +544,7 @@ export class RtkGrid {
             participants: this.participants,
             screenShareParticipants: this.screenShareParticipants,
             plugins: this.plugins,
+            activeCustomPlugins: this.activeCustomPlugins,
             pinnedParticipants: this.pinnedParticipants,
             aspectRatio: this.aspectRatio,
             gap: this.gap,

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Element, Prop, Watch, Event, EventEmitter } from '@stencil/core';
 import deepMerge from 'lodash-es/merge';
-import { PermissionSettings, Size, States } from '../../types/props';
+import { CustomPlugin, PermissionSettings, Size, States } from '../../types/props';
 import { getSize } from '../../utils/size';
 import { Meeting, RoomLeftState } from '../../types/rtk-client';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -120,6 +120,10 @@ export class RtkMeeting {
   @Prop()
   iconPack: IconPack = defaultIconPack;
 
+  /** Custom Plugins */
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
+
   /** UI Kit Overrides */
   @Prop()
   overrides: Overrides = defaultOverrides;
@@ -155,6 +159,7 @@ export class RtkMeeting {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
+    this.customPluginsChanged(this.customPlugins);
     this.overridesChanged(this.overrides);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
@@ -258,6 +263,7 @@ export class RtkMeeting {
         t: this.t,
         providerId: this.providerId,
         overrides: deepMerge({ ...defaultOverrides }, this.overrides) as Overrides,
+        customPlugins: this.customPlugins,
       }) as RtkUiStoreExtended;
 
       // Notify components that peer specific store is now available
@@ -301,6 +307,7 @@ export class RtkMeeting {
     ) {
       provideRtkDesignSystem(document.documentElement, this.config.designTokens);
     }
+
     meeting.self.addListener('roomJoined', this.roomJoinedListener);
     meeting.self.addListener('waitlisted', this.waitlistedListener);
     meeting.self.addListener('roomLeft', this.roomLeftListener);
@@ -368,6 +375,13 @@ export class RtkMeeting {
       (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
     ) {
       provideRtkDesignSystem(document.documentElement, config.designTokens);
+    }
+  }
+
+  @Watch('customPlugins')
+  customPluginsChanged(customPlugins: CustomPlugin[]) {
+    if (this.peerStore) {
+      this.peerStore.state.customPlugins = customPlugins;
     }
   }
 

--- a/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
+++ b/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
@@ -7,7 +7,7 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Render } from '../../lib/render';
 import { Meeting, Peer } from '../../types/rtk-client';
-import { Size, States } from '../../types/props';
+import { CustomPlugin, Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { GridLayout, GridSize } from '../rtk-grid/rtk-grid';
 import { SyncWithStore } from '../../utils/sync-with-store';
@@ -23,6 +23,8 @@ import type { Tab } from '../rtk-tab-bar/rtk-tab-bar';
 })
 export class RtkMixedGrid {
   private activeTabUpdateListener: (data: ActiveTab) => void;
+  private customPluginStoreSubscription: () => void;
+  private customPluginStoreRetryInterval: ReturnType<typeof setInterval>;
 
   /** Grid Layout */
   @Prop({ reflect: true }) layout: GridLayout = 'row';
@@ -38,6 +40,13 @@ export class RtkMixedGrid {
 
   /** Active Plugins */
   @Prop() plugins: RTKPlugin[] = [];
+
+  @State() activeCustomPlugins: CustomPlugin[] = [];
+
+  /** Custom Plugins */
+  @SyncWithStore()
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
 
   /**
    * Aspect Ratio of participant tile
@@ -100,6 +109,15 @@ export class RtkMixedGrid {
 
   disconnectedCallback() {
     this.meeting.meta?.removeListener('activeTabUpdate', this.activeTabUpdateListener);
+    if (this.customPluginStoreRetryInterval) {
+      clearInterval(this.customPluginStoreRetryInterval);
+      this.customPluginStoreRetryInterval = null;
+    }
+    if (this.customPluginStoreSubscription) {
+      const store = this.meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+      store?.unsubscribe('activePlugins', this.customPluginStoreSubscription);
+      this.customPluginStoreSubscription = null;
+    }
   }
 
   @Watch('meeting')
@@ -114,6 +132,7 @@ export class RtkMixedGrid {
       };
 
       meeting.meta?.addListener('activeTabUpdate', this.activeTabUpdateListener);
+      this.subscribeToCustomPluginStore(meeting);
     }
   }
 
@@ -142,11 +161,31 @@ export class RtkMixedGrid {
     }
   }
 
+  @Watch('activeCustomPlugins')
+  activeCustomPluginsChanged(activeCustomPlugins: CustomPlugin[]) {
+    if (!this.initialised && this.activeTab != null) return;
+
+    if (activeCustomPlugins.length > 0) {
+      const lastIndex = activeCustomPlugins.length - 1;
+      this.setActiveTab({
+        type: 'custom-plugin',
+        customPlugin: activeCustomPlugins[lastIndex],
+      });
+    } else {
+      this.revalidateActiveTab();
+    }
+  }
+
   private revalidateActiveTab() {
     if (this.activeTab != null) {
       if (this.activeTab.type === 'screenshare') {
         const { participant } = this.activeTab;
         if (!this.screenShareParticipants.some((p) => p.id === participant.id)) {
+          this.reassignActiveTab();
+        }
+      } else if (this.activeTab.type === 'custom-plugin') {
+        const { customPlugin } = this.activeTab;
+        if (!this.activeCustomPlugins.some((cp) => cp.id === customPlugin.id)) {
           this.reassignActiveTab();
         }
       } else {
@@ -160,13 +199,23 @@ export class RtkMixedGrid {
 
   private setActiveTab(activeTab: Tab, shouldUpdateSelfActiveTab: boolean = true) {
     this.activeTab = activeTab;
+    if (activeTab.type === 'custom-plugin') {
+      // Custom plugins don't use meeting.meta.setSelfActiveTab
+      return;
+    }
     const id = activeTab.type === 'screenshare' ? activeTab.participant.id : activeTab.plugin.id;
     if (shouldUpdateSelfActiveTab)
-      this.meeting.meta?.setSelfActiveTab({ type: activeTab.type, id }, 0);
+      this.meeting.meta?.setSelfActiveTab({ type: activeTab.type as ActiveTabType, id }, 0);
   }
 
   private reassignActiveTab() {
-    if (this.screenShareParticipants.length > 0) {
+    if (this.activeCustomPlugins.length > 0) {
+      const lastIndex = this.activeCustomPlugins.length - 1;
+      this.setActiveTab({
+        type: 'custom-plugin',
+        customPlugin: this.activeCustomPlugins[lastIndex],
+      });
+    } else if (this.screenShareParticipants.length > 0) {
       this.setActiveTab({ type: 'screenshare', participant: this.screenShareParticipants[0] });
     } else if (this.plugins.length > 0) {
       const lastIndex = this.plugins.length - 1;
@@ -189,14 +238,53 @@ export class RtkMixedGrid {
     }
   }
 
+  // NOTE(retry): The store should be available immediately since the SDK awaits
+  // storesManager.create('__internal_rtk_custom_plugins') in Controller.init().
+  // However, there is currently a timing issue where either the store or
+  // customPlugins (via @SyncWithStore) may not be ready when meetingChanged fires.
+  // Retry is a temporary workaround until the root cause is fixed.
+  private subscribeToCustomPluginStore(meeting: Meeting) {
+    const trySubscribe = () => {
+      const store = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+      if (!store || !this.customPlugins?.length) return false;
+      const activeIds: string[] = store.get('activePlugins') || [];
+      this.activeCustomPlugins = (this.customPlugins || []).filter((cp) =>
+        activeIds.includes(cp.id)
+      );
+      this.customPluginStoreSubscription = () => {
+        const s = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+        const ids: string[] = s?.get('activePlugins') || [];
+        this.activeCustomPlugins = (this.customPlugins || []).filter((cp) => ids.includes(cp.id));
+      };
+      store.subscribe('activePlugins', this.customPluginStoreSubscription);
+      return true;
+    };
+
+    if (trySubscribe()) return;
+
+    let attempts = 0;
+    this.customPluginStoreRetryInterval = setInterval(() => {
+      attempts++;
+      if (trySubscribe() || attempts >= 20) {
+        clearInterval(this.customPluginStoreRetryInterval);
+        this.customPluginStoreRetryInterval = null;
+      }
+    }, 500);
+  }
+
   private getTabs() {
+    const customPlugins = this.activeCustomPlugins.map((customPlugin) => ({
+      type: 'custom-plugin',
+      customPlugin,
+    }));
+
     const screenshares = this.screenShareParticipants.map((participant) => ({
       type: 'screenshare',
       participant,
     }));
 
     const plugins = this.plugins.map((plugin) => ({ type: 'plugin', plugin }));
-    return (screenshares as any[]).concat(plugins);
+    return (customPlugins as any[]).concat(screenshares).concat(plugins);
   }
 
   render() {
@@ -222,6 +310,20 @@ export class RtkMixedGrid {
             />
           )}
           <div id="tabs" key="tabs">
+            {this.activeCustomPlugins.map((cp) => (
+              <rtk-plugin-main
+                {...defaults}
+                customPlugin={cp}
+                key={cp.id}
+                style={{
+                  display:
+                    this.activeTab?.type === 'custom-plugin' &&
+                    this.activeTab?.customPlugin?.id === cp.id
+                      ? 'flex'
+                      : 'none',
+                }}
+              />
+            ))}
             {this.screenShareParticipants.map((participant) => (
               <Render
                 element="rtk-screenshare-view"

--- a/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.css
+++ b/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.css
@@ -10,7 +10,11 @@ header {
   @apply bg-background-900;
 
   & > div {
-    @apply flex items-center;
+    @apply flex items-center gap-2;
+  }
+
+  & > div > rtk-icon {
+    @apply h-5 w-5;
   }
 }
 
@@ -40,4 +44,8 @@ iframe {
 
 iframe {
   @apply h-full w-full;
+}
+
+.custom-plugin-container {
+  @apply flex-1 overflow-auto;
 }

--- a/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.tsx
+++ b/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.tsx
@@ -2,6 +2,7 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RTKPermissionsPreset, RTKPlugin } from '@cloudflare/realtimekit';
 import { Component, Host, h, Prop, Watch, State, writeTask } from '@stencil/core';
 import { Meeting } from '../../types/rtk-client';
+import { CustomPlugin } from '../../types/props';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 
@@ -16,6 +17,7 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 export class RtkPluginMain {
   private iframeEl: HTMLIFrameElement;
   private toggleViewModeListener: (data: boolean) => void;
+  private customPluginContainerEl: HTMLDivElement;
 
   /** Meeting */
   @SyncWithStore()
@@ -23,7 +25,15 @@ export class RtkPluginMain {
   meeting: Meeting;
 
   /** Plugin */
-  @Prop() plugin!: RTKPlugin;
+  @Prop() plugin: RTKPlugin;
+
+  /** Custom Plugin (when rendering a custom plugin instead of an ordinary one) */
+  @Prop() customPlugin: CustomPlugin | null = null;
+
+  /** Custom Plugins */
+  @SyncWithStore()
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
 
   /** Icon pack */
   @SyncWithStore()
@@ -53,6 +63,8 @@ export class RtkPluginMain {
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
     if (!meeting) return;
+    if (this.customPlugin != null) return;
+    if (this.plugin == null) return;
     const enabled = this.canInteractWithPlugin();
     this.viewModeEnabled = !enabled;
     writeTask(() => {
@@ -77,7 +89,29 @@ export class RtkPluginMain {
   disconnectedCallback() {
     this.plugin?.removePluginView('plugin-main');
     this.plugin?.removeListener('toggleViewMode', this.toggleViewModeListener);
+    if (this.customPluginContainerEl && this.customPlugin?.component) {
+      if (this.customPluginContainerEl.contains(this.customPlugin.component)) {
+        this.customPluginContainerEl.removeChild(this.customPlugin.component);
+      }
+    }
   }
+
+  private deactivateCustomPlugin = () => {
+    const store = this.meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+    if (!this.customPlugin || !store) return;
+    const current: string[] = store.get('activePlugins') || [];
+    const newIds = current.filter((id) => id !== this.customPlugin.id);
+    store.set('activePlugins', newIds, true, true);
+  };
+
+  private onCustomPluginContainerRef = (el: HTMLDivElement) => {
+    if (!el || el === this.customPluginContainerEl) return;
+    this.customPluginContainerEl = el;
+    if (this.customPlugin?.component && !el.contains(this.customPlugin.component)) {
+      el.innerHTML = '';
+      el.appendChild(this.customPlugin.component);
+    }
+  };
 
   private canInteractWithPlugin = () => {
     const pluginId = this.plugin.id;
@@ -108,6 +142,27 @@ export class RtkPluginMain {
   };
 
   render() {
+    if (this.customPlugin != null) {
+      return (
+        <Host>
+          <header part="header">
+            <div>
+              <rtk-icon icon={this.customPlugin.icon} />
+              {this.customPlugin.name}
+            </div>
+            {this.customPlugin.canClosePlugin && (
+              <div>
+                <rtk-button kind="icon" onClick={this.deactivateCustomPlugin} part="button">
+                  <rtk-icon icon={this.iconPack.dismiss} />
+                </rtk-button>
+              </div>
+            )}
+          </header>
+          <div class="custom-plugin-container" ref={(el) => this.onCustomPluginContainerRef(el)} />
+        </Host>
+      );
+    }
+
     if (this.plugin == null) return null;
 
     return (

--- a/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
+++ b/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { Meeting } from '../../types/rtk-client';
-import { Size, States } from '../../types/props';
+import { CustomPlugin, Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RTKPlugin } from '@cloudflare/realtimekit';
@@ -19,6 +19,9 @@ import { createDefaultConfig } from '../../exports';
 })
 export class RtkPlugins {
   private updateActivePlugins: () => void;
+  private customPluginStoreSubscription: () => void;
+  private customPluginStoreRetryInterval: ReturnType<typeof setInterval>;
+
   /** Meeting object */
   @SyncWithStore()
   @Prop()
@@ -42,6 +45,16 @@ export class RtkPlugins {
   @Prop()
   t: RtkI18n = useLanguage();
 
+  /** States */
+  @SyncWithStore()
+  @Prop()
+  states: States;
+
+  /** Custom Plugins */
+  @SyncWithStore()
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
+
   /** Emits updated state data */
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
@@ -53,12 +66,22 @@ export class RtkPlugins {
 
   @State() activatedPluginsId: string[] = [];
 
+  @State() activeCustomPluginIds: string[] = [];
+
   connectedCallback() {
     this.meetingChanged(this.meeting);
   }
 
   disconnectedCallback() {
     this.meeting?.plugins.all.removeListener('stateUpdate', this.updateActivePlugins);
+    if (this.customPluginStoreRetryInterval) {
+      clearInterval(this.customPluginStoreRetryInterval);
+      this.customPluginStoreRetryInterval = null;
+    }
+    if (this.customPluginStoreSubscription) {
+      const store = this.meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+      store?.unsubscribe('activePlugins', this.customPluginStoreSubscription);
+    }
   }
 
   @Watch('meeting')
@@ -75,7 +98,60 @@ export class RtkPlugins {
       };
       this.updateActivePlugins();
       meeting.plugins.all.addListener('stateUpdate', this.updateActivePlugins);
+
+      this.subscribeToCustomPluginStore(meeting);
     }
+  }
+
+  private activateCustomPlugin = (plugin: CustomPlugin) => {
+    const store = this.meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+    if (!store) return;
+    const current: string[] = store.get('activePlugins') || [];
+    if (!current.includes(plugin.id)) {
+      const newIds = [...current, plugin.id];
+      store.set('activePlugins', newIds, true, true);
+      this.activeCustomPluginIds = newIds;
+    }
+    this.close();
+  };
+
+  private deactivateCustomPlugin = (plugin: CustomPlugin) => {
+    const store = this.meeting?.stores?.stores?.get('__internal_rtk_custom_plugins');
+    if (!store) return;
+    const current: string[] = store.get('activePlugins') || [];
+    const newIds = current.filter((id) => id !== plugin.id);
+    store.set('activePlugins', newIds, true, true);
+    this.activeCustomPluginIds = newIds;
+  };
+
+  // NOTE(retry): The store should be available immediately since the SDK awaits
+  // storesManager.create('__internal_rtk_custom_plugins') in Controller.init().
+  // However, there is currently a timing issue where either the store or
+  // customPlugins (via @SyncWithStore) may not be ready when meetingChanged fires.
+  // Retry is a temporary workaround until the root cause is fixed.
+  private subscribeToCustomPluginStore(meeting: Meeting) {
+    const trySubscribe = () => {
+      const store = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+      if (!store || !this.customPlugins?.length) return false;
+      this.activeCustomPluginIds = store.get('activePlugins') || [];
+      this.customPluginStoreSubscription = () => {
+        const s = meeting.stores?.stores?.get('__internal_rtk_custom_plugins');
+        this.activeCustomPluginIds = s?.get('activePlugins') || [];
+      };
+      store.subscribe('activePlugins', this.customPluginStoreSubscription);
+      return true;
+    };
+
+    if (trySubscribe()) return;
+
+    let attempts = 0;
+    this.customPluginStoreRetryInterval = setInterval(() => {
+      attempts++;
+      if (trySubscribe() || attempts >= 20) {
+        clearInterval(this.customPluginStoreRetryInterval);
+        this.customPluginStoreRetryInterval = null;
+      }
+    }, 500);
   }
 
   private close = () => {
@@ -86,6 +162,38 @@ export class RtkPlugins {
     return (
       <Host>
         <ul class="scrollbar">
+          {this.customPlugins?.map((cp) => (
+            <li key={cp.id} class="plugin">
+              <div class="metadata">
+                <rtk-icon icon={cp.icon} size="md" />
+                <div class="name">{cp.name}</div>
+              </div>
+              {!this.activeCustomPluginIds.includes(cp.id) && cp.canOpenPlugin && (
+                <div class="buttons">
+                  <rtk-button
+                    kind="icon"
+                    size="lg"
+                    onClick={() => this.activateCustomPlugin(cp)}
+                    aria-label={`${this.t('activate')} ${cp.name}`}
+                  >
+                    <rtk-icon icon={this.iconPack.rocket} tabIndex={-1} aria-hidden={true} />
+                  </rtk-button>
+                </div>
+              )}
+              {this.activeCustomPluginIds.includes(cp.id) && cp.canClosePlugin && (
+                <div class="buttons">
+                  <rtk-button
+                    kind="icon"
+                    size="lg"
+                    onClick={() => this.deactivateCustomPlugin(cp)}
+                    aria-label={`${this.t('close')} ${cp.name}`}
+                  >
+                    <rtk-icon icon={this.iconPack.dismiss} tabIndex={-1} aria-hidden={true} />
+                  </rtk-button>
+                </div>
+              )}
+            </li>
+          ))}
           {this.plugins.map((plugin) => (
             <li key={plugin.name} class="plugin">
               <div class="metadata">

--- a/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.css
+++ b/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.css
@@ -23,12 +23,13 @@ rtk-button {
   @apply bg-brand;
 }
 
-.tab img {
+.tab img,
+.tab rtk-icon {
   @apply h-7 w-7 rounded-sm;
 }
 
 .tab .name {
-  @apply mt-0.5;
+  @apply mt-0.5 w-full overflow-hidden text-ellipsis whitespace-nowrap text-center;
 }
 
 :host([size='sm']) {

--- a/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
+++ b/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { RTKPlugin } from '@cloudflare/realtimekit';
 import type { ActiveTabType } from '@cloudflare/realtimekit';
+import { CustomPlugin } from '../../types/props';
 import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -12,9 +13,10 @@ import { SyncWithStore } from '../../utils/sync-with-store';
 import { GridLayout } from '../rtk-grid/rtk-grid';
 
 export interface Tab {
-  type: ActiveTabType;
+  type: ActiveTabType | 'custom-plugin';
   participant?: Peer;
   plugin?: RTKPlugin;
+  customPlugin?: CustomPlugin;
 }
 
 @Component({
@@ -75,6 +77,12 @@ export class RtkTabBar {
         {this.tabs.map((tab: Tab) => {
           let isActive = false;
           if (
+            this.activeTab?.type === 'custom-plugin' &&
+            tab.customPlugin &&
+            this.activeTab?.customPlugin.id === tab.customPlugin.id
+          )
+            isActive = true;
+          else if (
             this.activeTab?.type === 'plugin' &&
             tab.plugin &&
             this.activeTab?.plugin.id === tab.plugin.id
@@ -106,6 +114,26 @@ export class RtkTabBar {
                   <span class="name">
                     {participant.id === this.meeting?.self.id ? this.t('you') : shorten(name, 6)}
                   </span>
+                </div>
+              </rtk-button>
+            );
+          } else if (tab.type === 'custom-plugin') {
+            const cp = tab.customPlugin;
+            return (
+              <rtk-button
+                title={cp.name}
+                key={cp.id}
+                kind="icon"
+                variant={isActive ? 'primary' : 'secondary'}
+                class={{
+                  tab: true,
+                  active: isActive,
+                }}
+                onClick={() => this.tabChange.emit(tab)}
+              >
+                <div class="center col">
+                  <rtk-icon icon={cp.icon} />
+                  <span class="name">{shorten(cp.name, 6)}</span>
                 </div>
               </rtk-button>
             );

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -13,6 +13,7 @@ import {
   Overrides,
   defaultOverrides,
 } from '../../exports';
+import { CustomPlugin } from '../../types/props';
 import {
   uiStore as legacyGlobalUIStore,
   createPeerStore,
@@ -58,6 +59,10 @@ export class RtkUiProvider {
   /** Whether to show setup screen or not */
   @Prop() showSetupScreen: boolean = false;
 
+  /** Custom Plugins */
+  @Prop()
+  customPlugins: CustomPlugin[] = [];
+
   /** UI Kit Overrides */
   @Prop()
   overrides: Overrides = defaultOverrides;
@@ -87,6 +92,7 @@ export class RtkUiProvider {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
+    this.customPluginsChanged(this.customPlugins);
     this.overridesChanged(this.overrides);
   }
 
@@ -177,6 +183,7 @@ export class RtkUiProvider {
         t: this.t,
         providerId: this.providerId,
         overrides: deepMerge({ ...defaultOverrides }, this.overrides) as Overrides,
+        customPlugins: this.customPlugins,
       }) as RtkUiStoreExtended;
 
       // Notify components that peer specific store is now available
@@ -248,6 +255,13 @@ export class RtkUiProvider {
       (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
     ) {
       provideRtkDesignSystem(document.documentElement, config.designTokens);
+    }
+  }
+
+  @Watch('customPlugins')
+  customPluginsChanged(customPlugins: CustomPlugin[]) {
+    if (this.peerStore) {
+      this.peerStore.state.customPlugins = customPlugins;
     }
   }
 

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -24,6 +24,7 @@ export {
   UserPreferences,
   PollObject,
   PartialStateEvent,
+  CustomPlugin,
 } from './types/props';
 export { Peer } from './types/rtk-client';
 

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -488,9 +488,7 @@
           },
           async initialize() {
             const url = new URL(window.location.href);
-            const authToken =
-              url.searchParams.get('authToken') ||
-              'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdJZCI6ImJhMTU5YmUwLTI4YWMtNDllMi1hNWQzLTRiYzc3OGUzNzc1ZCIsIm1lZXRpbmdJZCI6ImJiYmY3NDFmLWU5NzgtNGY5MS1iN2RkLWQ4MGNlNGMzNzhjYyIsInBhcnRpY2lwYW50SWQiOiJhYWFlMDYwZi1lODZjLTRiYTctYmQwOS05NTY2MWI0NWM1ZDEiLCJwcmVzZXRJZCI6IjZmMTBiMzYyLWQ3YzMtNDE3Mi1hMzNjLTZkMTc3N2U0MjVkOCIsImlhdCI6MTc3NTU1MTYzOCwiZXhwIjoxNzg0MTkxNjM4fQ.ja1mN04mIjAECF5hhB07lqYe-bBsJ4puIiQ1hBQ80MGblxHsXCezzY7MLT9nhyo0M_6EeYsq_ECP4qVmcoz7B7CdJ0L74V9hCWMtecHlzGfWZqJE8lDu0PBvzh7w4i8GUO2x6H_5VTd3O-HEZxFJ9Vz8Vt_o58ZaieEGNfEHAgzFOfP6JarhZHOOz6XJLhVFfE8xO0KzJgCar2yXOIQm_A_en0rn3DDiKZ2vmrFac1p_WH_5e597Hm4z8FcaL85ESPYnVJQay4fQVCcNRRng_AjtzZUc08VpteuAQgRKf28pvgPEnRawtuCQ1THpkt3lAn_WRtzTfCfy5J5wNN5PDg';
+            const authToken = url.searchParams.get('authToken');
             const env = url.searchParams.get('env') || 'prod';
             const showSetupScreen = url.searchParams.get('showSetupScreen');
             const enableVideo = url.searchParams.get('enableVideo');

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -359,14 +359,125 @@
     <script src="https://unpkg.com/alpinejs@3.8.1/dist/cdn.min.js" defer></script>
 
     <script>
+      const todoAppEl = document.createElement('iframe');
+      todoAppEl.id = 'todo-plugin';
+      todoAppEl.src = 'https://realtimekit-plugin-todo-app.cf-realtime.workers.dev/';
+      todoAppEl.style.cssText = 'width:100%;height:100%;border:none;';
+
+      function connectToDoListPluginToMeeting(meeting, iframe) {
+        var STORE_NAME = 'realtimekit-plugin-todo-store-' + iframe.id;
+        var store = null;
+
+        var methods = {
+          init: async function () {
+            store = await meeting.stores.create(STORE_NAME);
+          },
+          setTask: async function (data) {
+            return await store.set(data.id, data.task);
+          },
+          fetchTask: async function (data) {
+            return store.get(data.id);
+          },
+          fetchAllTasks: async function () {
+            return store.getAll();
+          },
+          addTaskToTrash: async function (data) {
+            var task = store.get(data.id);
+            if (!task) throw new Error('Task not found: ' + data.id);
+            return await store.set(data.id, Object.assign({}, task, { state: 'deleted' }));
+          },
+          removeTaskPermanently: async function (data) {
+            return store.delete(data.id);
+          },
+          subscribe: async function () {
+            store.subscribe('*', function (event) {
+              iframe.contentWindow.postMessage(
+                { type: 'plugin-event', event: 'data-update', data: event },
+                '*'
+              );
+            });
+          },
+        };
+
+        window.addEventListener('message', async function (event) {
+          if (event.source !== iframe.contentWindow) return;
+          var msg = event.data;
+          if (!msg || typeof msg !== 'object') return;
+
+          if (msg.type === 'rtk-plugin-ready') {
+            iframe.contentWindow.postMessage({ type: 'rtk-plugin-init' }, '*');
+            return;
+          }
+
+          if (msg.type === 'plugin-request') {
+            var fn = methods[msg.method];
+            if (!fn) {
+              iframe.contentWindow.postMessage(
+                { type: 'plugin-response', id: msg.id, error: 'Unknown method: ' + msg.method },
+                '*'
+              );
+              return;
+            }
+            try {
+              var result = await fn(msg.data);
+              iframe.contentWindow.postMessage(
+                { type: 'plugin-response', id: msg.id, result: result },
+                '*'
+              );
+            } catch (e) {
+              iframe.contentWindow.postMessage(
+                { type: 'plugin-response', id: msg.id, error: e.message },
+                '*'
+              );
+            }
+          }
+        });
+      }
+
+      const youtubeRickrollEl = document.createElement('iframe');
+      youtubeRickrollEl.src = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+      youtubeRickrollEl.style.cssText = 'width:100%;height:100%;border:none;';
+
+      const helloWorldEl = document.createElement('div');
+      helloWorldEl.style.cssText =
+        'display:flex;align-items:center;justify-content:center;height:100%;width:100%;background:#1a1a2e;color:#fff;font-family:sans-serif;flex-direction:column;gap:12px;';
+      helloWorldEl.innerHTML =
+        '<h1 style="font-size:2rem;margin:0;">👋 Hello World Plugin</h1><p style="color:#aaa;margin:0;">This is a custom plugin passed to rtk-meeting.</p>';
+
       const app = () => {
         return {
           meeting: null,
           joining: false,
           status: 'Joining...',
+          customPlugins: [
+            {
+              id: 'hello-world',
+              name: 'Hello World',
+              icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><rect width="36" height="36" rx="8" fill="#6366f1"/><g transform="translate(6,6)" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></g></svg>',
+              canOpenPlugin: true,
+              canClosePlugin: true,
+              component: helloWorldEl,
+            },
+            {
+              id: 'youtube-rickroll',
+              name: 'YouTube Rickroll',
+              icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><rect width="36" height="36" rx="8" fill="#ef4444"/><g transform="translate(6,6)" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></g></svg>',
+              canOpenPlugin: true,
+              canClosePlugin: true,
+              component: youtubeRickrollEl,
+            },
+            {
+              id: 'todo-app',
+              name: 'TODO List',
+              icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><rect width="36" height="36" rx="8" fill="#10b981"/><g transform="translate(6,6)" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></g></svg>',
+              canOpenPlugin: true,
+              canClosePlugin: true,
+              component: todoAppEl,
+            },
+          ],
           data: {
             authToken: '',
-            env: 'preprod',
+            env: 'prod',
             showSetupScreen: false,
             defaults: {
               audio: false,
@@ -377,8 +488,10 @@
           },
           async initialize() {
             const url = new URL(window.location.href);
-            const authToken = url.searchParams.get('authToken');
-            const env = url.searchParams.get('env');
+            const authToken =
+              url.searchParams.get('authToken') ||
+              'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdJZCI6ImJhMTU5YmUwLTI4YWMtNDllMi1hNWQzLTRiYzc3OGUzNzc1ZCIsIm1lZXRpbmdJZCI6ImJiYmY3NDFmLWU5NzgtNGY5MS1iN2RkLWQ4MGNlNGMzNzhjYyIsInBhcnRpY2lwYW50SWQiOiJhYWFlMDYwZi1lODZjLTRiYTctYmQwOS05NTY2MWI0NWM1ZDEiLCJwcmVzZXRJZCI6IjZmMTBiMzYyLWQ3YzMtNDE3Mi1hMzNjLTZkMTc3N2U0MjVkOCIsImlhdCI6MTc3NTU1MTYzOCwiZXhwIjoxNzg0MTkxNjM4fQ.ja1mN04mIjAECF5hhB07lqYe-bBsJ4puIiQ1hBQ80MGblxHsXCezzY7MLT9nhyo0M_6EeYsq_ECP4qVmcoz7B7CdJ0L74V9hCWMtecHlzGfWZqJE8lDu0PBvzh7w4i8GUO2x6H_5VTd3O-HEZxFJ9Vz8Vt_o58ZaieEGNfEHAgzFOfP6JarhZHOOz6XJLhVFfE8xO0KzJgCar2yXOIQm_A_en0rn3DDiKZ2vmrFac1p_WH_5e597Hm4z8FcaL85ESPYnVJQay4fQVCcNRRng_AjtzZUc08VpteuAQgRKf28pvgPEnRawtuCQ1THpkt3lAn_WRtzTfCfy5J5wNN5PDg';
+            const env = url.searchParams.get('env') || 'prod';
             const showSetupScreen = url.searchParams.get('showSetupScreen');
             const enableVideo = url.searchParams.get('enableVideo');
             const enableAudio = url.searchParams.get('enableAudio');
@@ -456,8 +569,12 @@
 
             const { env } = this.data;
 
-            const apiBase = env === 'prod' ? 'https://api.dyte.io' : `https://api.${env}.dyte.io`;
-            const baseURI = env === 'prod' ? 'dyte.io' : `${env}.dyte.io`;
+            const apiBase =
+              env === 'prod'
+                ? 'https://api.realtime.cloudflare.com'
+                : `https://api.${env}.realtime.cloudflare.com`;
+            const baseURI =
+              env === 'prod' ? 'realtime.cloudflare.com' : `${env}.realtime.cloudflare.com`;
 
             this.status = 'Getting meeting details...';
 
@@ -515,7 +632,9 @@
           attachMeetingObject(meeting, log = false) {
             this.meeting = meeting;
             this.$refs.meeting.meeting = meeting;
+            this.$refs.meeting.customPlugins = this.customPlugins;
             window.meeting = meeting;
+            connectToDoListPluginToMeeting(meeting, todoAppEl);
           },
         };
       };

--- a/packages/core/src/lib/grid.ts
+++ b/packages/core/src/lib/grid.ts
@@ -151,7 +151,7 @@ export function useGridPositioning({
  * @returns The parsed value of aspect ratio
  */
 export const getAspectRatio = (ratio: string): number => {
-  const [width, height] = ratio.split(':');
+  const [width, height] = (ratio || '16:9').split(':');
   return Number.parseInt(height) / Number.parseInt(width);
 };
 

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -30,6 +30,15 @@ export interface PermissionSettings {
   kind?: 'audio' | 'video' | 'screenshare';
 }
 
+export interface CustomPlugin {
+  id: string;
+  name: string;
+  icon: string;
+  canOpenPlugin: boolean;
+  canClosePlugin: boolean;
+  component: HTMLElement;
+}
+
 /**
  * Global States object which are shared among components
  */

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -2,7 +2,7 @@ import { createStore, ObservableMap } from '@stencil/store';
 import { Meeting, RealtimeKitClient } from '../../types/rtk-client';
 import { useLanguage, type RtkI18n } from '../../lib/lang';
 import { defaultIconPack, type IconPack } from '../../lib/icons';
-import { type States } from '../../types/props';
+import { type States, type CustomPlugin } from '../../types/props';
 import { getUserPreferences } from '../user-prefs';
 import { createDefaultConfig, UIConfig } from '../../exports';
 import { type Overrides, defaultOverrides } from '../../lib/overrides';
@@ -19,6 +19,7 @@ export interface RtkUiStore {
   iconPack: IconPack;
   states: States;
   config: UIConfig;
+  customPlugins: CustomPlugin[];
   peerId: string | null;
   storeType: 'global' | 'peer';
   storeId: string;
@@ -36,6 +37,7 @@ const uiStore = createStore<RtkUiStore>({
   iconPack: defaultIconPack,
   states: getInitialStates(),
   config: createDefaultConfig(),
+  customPlugins: [],
   peerId: 'global',
   storeType: 'global',
   storeId: 'store-global',
@@ -79,6 +81,7 @@ export function createPeerStore({
   iconPack,
   t,
   overrides,
+  customPlugins,
 }: {
   meeting: RealtimeKitClient;
   config?: UIConfig;
@@ -86,6 +89,7 @@ export function createPeerStore({
   iconPack: IconPack;
   t: RtkI18n;
   overrides?: Overrides;
+  customPlugins?: CustomPlugin[];
 }): RtkUiStoreExtended {
   const store = createStore<RtkUiStore>({
     meeting: meeting,
@@ -93,6 +97,7 @@ export function createPeerStore({
     iconPack,
     states: getInitialStates(meeting.self.peerId),
     config: config || createDefaultConfig(),
+    customPlugins: customPlugins || [],
     peerId: meeting.self.id,
     storeType: 'peer',
     // Use provider id's numeric portion as store id for easier debugging


### PR DESCRIPTION
### Description

Currently custom plugins are very hard to build and require understanding multiple SDKs. With this proposal, any custom component, built using any framework can be used as plugin in RealtimeKit as long as it is a HTMLComponent. Few sample custom plugins are available in index.html.
