### PR TITLE
ci: declare permissions on lint, test, pr-comment, release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write   # gh pr comment posts a comment on the PR
+
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
   repository_dispatch:
     types: [prod-release]
 
+# semantic-release creates GitHub releases (+ tags + release notes) and
+# updates the changelog commit; the "Update staging branch" step pushes
+# main onto staging. issues + pull-requests writes cover semantic-release's
+# comment-on-release-PR-and-issue behavior.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - staging
       - main
+
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds explicit top-level `permissions:` to the four workflows still relying on default token scopes:

- **lint.yml** + **test.yml**: `contents: read`. Pure CI — install deps, lint/build, run tests.
- **pr-comment.yml**: `contents: read` + `pull-requests: write`. The step runs `gh pr comment$PR_NUMBER --body ...` with `GITHUB_TOKEN`; `pull-requests: write` is the documented scope for the comments API.
- **release.yml**: `contents: write` + `issues: write` + `pull-requests: write`. `npx semantic-release` creates the GitHub release/tag and posts the released-issue/PR comments. The final `git push --set-upstream origin staging` step also needs `contents: write`. The npm publish step uses `NPM_PUBLISH_TOKEN`, not the GitHub token.

Already-hardened siblings (`ai-pr-review.yml`, `bonk.yml`, `update-docs.yml`) follow the same top-level approach. YAML validated with `yaml.safe_load`.