### PR TITLE
fix: ignore non-fatal ClientError codes in init error listener

### DIFF
--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -137,8 +137,10 @@ export class RtkMeeting {
   connectedCallback() {
     if (typeof window !== 'undefined') {
       this.initErrorListener = (ev) => {
-        const { message, code } = getInitErrorInfo(this.t, ev.detail);
-        this.updateStates({ preJoinError: { message, code } });
+        const errorInfo = getInitErrorInfo(this.t, ev.detail);
+        if (errorInfo) {
+          this.updateStates({ preJoinError: errorInfo });
+        }
       };
       window.addEventListener('ClientError', this.initErrorListener);
     }

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -75,8 +75,10 @@ export class RtkUiProvider {
   connectedCallback() {
     if (typeof window !== 'undefined') {
       this.initErrorListener = (ev) => {
-        const { message, code } = getInitErrorInfo(this.t, ev.detail);
-        this.updateStates({ preJoinError: { message, code } });
+        const errorInfo = getInitErrorInfo(this.t, ev.detail);
+        if (errorInfo) {
+          this.updateStates({ preJoinError: errorInfo });
+        }
       };
       window.addEventListener('ClientError', this.initErrorListener);
     }

--- a/packages/core/src/utils/init-error.ts
+++ b/packages/core/src/utils/init-error.ts
@@ -7,12 +7,16 @@ import type { PreJoinError } from '../types/props';
  * Called by the `initErrorListener` in `rtk-meeting` and `rtk-ui-provider` when a
  * `ClientError` window event fires before the meeting object is available.
  *
- * Only handles error codes thrown by `Client.init()`:
+ * Only the codes below represent genuine `Client.init()` failures; any other code
+ * (e.g. non-fatal media/device errors) is not an init failure and returns `null`.
  *  - 0004 — Invalid auth token (401, 403, 404, malformed JWT)
  *  - 0001 — Failed to initialize (network, timeout, server 5xx, catch-all)
  *  - 0010 — Browser not supported (no RTCPeerConnection)
+ *  - 0904 — Could not load preset/permissions
+ *  - 0102 — Prerequisite module missing
+ *  - 0404 — Missing socket prerequisites (peerId, meetingId, authToken)
  */
-export function getInitErrorInfo(t: RtkI18n, err: unknown): PreJoinError {
+export function getInitErrorInfo(t: RtkI18n, err: unknown): PreJoinError | null {
   const code: string | undefined = (err as any)?.code;
 
   switch (code) {
@@ -25,7 +29,12 @@ export function getInitErrorInfo(t: RtkI18n, err: unknown): PreJoinError {
     case '0010':
       return { message: t('init.browser_error'), code };
 
-    default:
+    case '0904':
+    case '0102':
+    case '0404':
       return { message: t('init.default_error'), code };
+
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
## Description

Denying camera/mic permissions during `Client.init()` briefly shows a false 
"Something went wrong" error on the idle screen while init is still in progress,
even though these are non-fatal and don't affect the init outcome.

## Fix

`getInitErrorInfo` now returns `null` for non-init-failure codes.
`rtk-meeting` / `rtk-ui-provider` skip updating `preJoinError` when `null` is returned. Genuine init errors (auth, network, browser support, etc.) are unaffected.

Refs: RTK-8443, RTK-8511