### PR TITLE
ci: bump ask-bonk/opencode versions and harden PR review permissions

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -30,17 +30,20 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: Cloudflare-Studio/ask-bonk/github@5d4fe8f4a557afb1b73ec8c0ffcf60359a28865f # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-5'
+          variant: 'high'
           forks: 'false'
           permissions: write
-          opencode_version: '1.2.27'
+          # Pin for reproducible runs; bump deliberately after verifying
+          # no ProviderModelNotFoundError/ProviderInitError regressions.
+          opencode_version: '1.18.21'
           # The auto-reviewer must never push to PR branches. NO_PUSH
           # enforces contents: read at the token level so it holds even
           # if the model ignores prompt instructions.

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -35,6 +35,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Deny external_directory/doom_loop permission prompts outright so the
+          # agent never blocks on an unattended approval; it can still read/edit
+          # files within the checked-out repo.
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cloudflare-ai-gateway/anthropic/claude-opus-5'


### PR DESCRIPTION
### Description
Bumps the Bonk PR-review workflow and hardens it for unattended (headless) runs:

- Pin ask-bonk to Cloudflare-Studio/ask-bonk (repo moved orgs) at a commit SHA
- Bump opencode to 1.18.21 (was 1.2.27)
- Fix review model to claude-opus-5 (was invalid claude-opus-4-6, causing
  ProviderModelNotFoundError), with explicit variant: high
- Deny `external_directory` and `doom_loop` permission prompts. Both default to "ask",
  but the reviewer runs unattended with no one to approve, so an unanswered prompt blocks the job
  until it times out