### PR TITLE
fix(rtk-recording-toggle): show accurate error when a recording is already in progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,9 +1108,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/realtimekit": {
-      "version": "1.5.2-staging.9",
-      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.5.2-staging.9.tgz",
-      "integrity": "sha512-ZM+XbpE4pOcj/IlcR8ygY1xK0WegpX2HY1Y5NQQCTZlbvJhWaBD2lok/r7KXFWUL9ZsbTEeVfJ4n8GTAHVJL2Q==",
+      "version": "2.0.2-staging.8",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-2.0.2-staging.8.tgz",
+      "integrity": "sha512-5nUE9R+5L0aubuzuEkIq/FnANlJFLxJqco0BCKuZtd9cBRmgq1QjpCratw9I3CXZfE3+r/2Ao42silw92TZBFg==",
       "dev": true,
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",
@@ -26540,7 +26540,7 @@
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
-        "@cloudflare/realtimekit": "^1.5.2-staging.9",
+        "@cloudflare/realtimekit": "^2.0.2-staging.6",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {
-    "@cloudflare/realtimekit": "^1.5.2-staging.9",
+    "@cloudflare/realtimekit": "^2.0.2-staging.6",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.spec.tsx
+++ b/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.spec.tsx
@@ -1,0 +1,54 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { RtkRecordingToggle } from './rtk-recording-toggle';
+
+function createMeeting(startRecording: () => Promise<void>) {
+  return {
+    recording: {
+      recordingState: 'IDLE',
+      start: startRecording,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    },
+    self: {
+      permissions: {
+        canRecord: true,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      },
+    },
+  } as any;
+}
+
+describe('<rtk-recording-toggle>', () => {
+  it('shows an "already in progress" message when start() rejects with a 1005 conflict', async () => {
+    const page = await newSpecPage({
+      components: [RtkRecordingToggle],
+      html: `<rtk-recording-toggle></rtk-recording-toggle>`,
+    });
+    const instance = page.rootInstance as RtkRecordingToggle;
+    instance.meeting = createMeeting(() => Promise.reject({ code: '1005' }));
+    const apiErrorSpy = jest.fn();
+    page.root.addEventListener('rtkApiError', apiErrorSpy);
+
+    await (instance as any).toggleRecording();
+
+    expect(apiErrorSpy).toHaveBeenCalledTimes(1);
+    expect(apiErrorSpy.mock.calls[0][0].detail.message).toBe('A recording is already in progress.');
+  });
+
+  it('shows the generic start error message for any other failure', async () => {
+    const page = await newSpecPage({
+      components: [RtkRecordingToggle],
+      html: `<rtk-recording-toggle></rtk-recording-toggle>`,
+    });
+    const instance = page.rootInstance as RtkRecordingToggle;
+    instance.meeting = createMeeting(() => Promise.reject({ code: '1000' }));
+    const apiErrorSpy = jest.fn();
+    page.root.addEventListener('rtkApiError', apiErrorSpy);
+
+    await (instance as any).toggleRecording();
+
+    expect(apiErrorSpy).toHaveBeenCalledTimes(1);
+    expect(apiErrorSpy.mock.calls[0][0].detail.message).toBe('Error while starting recording.');
+  });
+});

--- a/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
+++ b/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
@@ -1,4 +1,4 @@
-import type { RecordingState } from '@cloudflare/realtimekit';
+import type { ClientError, RecordingState } from '@cloudflare/realtimekit';
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -98,10 +98,13 @@ export class RtkRecordingToggle {
         try {
           await this.meeting?.recording.start();
           return;
-        } catch {
+        } catch (error) {
+          const alreadyRecording = (error as ClientError)?.code === '1005';
           this.apiError.emit({
             trace: this.t('recording.start'),
-            message: this.t('recording.error.start'),
+            message: this.t(
+              alreadyRecording ? 'recording.error.already_recording' : 'recording.error.start'
+            ),
           });
         }
         return;

--- a/packages/core/src/lib/lang/default-language.ts
+++ b/packages/core/src/lib/lang/default-language.ts
@@ -187,6 +187,7 @@ export const defaultLanguage = {
   'recording.stopped': 'Recording for this meeting has been stopped.',
   'recording.paused': 'Recording for this meeting has been paused.',
   'recording.error.start': 'Error while starting recording.',
+  'recording.error.already_recording': 'A recording is already in progress.',
   'recording.error.stop': 'Error while stopping recording.',
   'recording.error.resume': 'Error while resuming recording.',
   'recording.start': 'Start Recording',


### PR DESCRIPTION
### Description

Clicking "Record" while a recording is starting always showed a generic "Error while starting recording.", instead of an accurate "already in progress" error.

### Fix
Check the caught error's code in the IDLE start path. Show "A recording is already in progress." when it's 1005, 
otherwise fall back to the generic message.

Also bumped the `@cloudflare/realtimekit` devDependency to `2.0.2-staging.6`, so this fix is available after merging.
The old `^1.5.2-staging.9` range can't resolve to it.

Fixes: RTK-8438
